### PR TITLE
Update Template Shader Functions

### DIFF
--- a/Assets/VivifyTemplate/Utilities/Shader Functions/Colors.cginc
+++ b/Assets/VivifyTemplate/Utilities/Shader Functions/Colors.cginc
@@ -1,3 +1,6 @@
+#ifndef VIVIFY_COLOR_FUNCTIONS_INCLUDED
+#define VIVIFY_COLOR_FUNCTIONS_INCLUDED
+
 float3 palette( in float t, in float3 a, in float3 b, in float3 c, in float3 d )
 {
     return a + b*cos( 6.28318*(c*t+d) );
@@ -8,6 +11,7 @@ float3 rainbow( in float t)
     return palette(t, 0.5, 0.5, 1, float3(0, 0.33, 0.66));
 }
 
+// Linear to gamma conversion
 float3 gammaCorrect( in float3 col)
 {
     return pow(saturate(col), 2.2);
@@ -23,13 +27,13 @@ float3 HUEtoRGB(in float H)
 }
 
 float Epsilon = 1e-10;
- 
+
 float3 RGBtoHCV(in float3 RGB)
 {
     // Based on work by Sam Hocevar and Emil Persson
-    float4 P = (RGB.g < RGB.b) ? float4(RGB.bg, -1.0, 2.0/3.0) : float4(RGB.gb, 0.0, -1.0/3.0);
-    float4 Q = (RGB.r < P.x) ? float4(P.xyw, RGB.r) : float4(RGB.r, P.yzx);
-    float C = Q.x - min(Q.w, Q.y);
+    float4 P = float4( max(RGB.g, RGB.b), min(RGB.g, RGB.b), -(RGB.g < RGB.b), (RGB.g < RGB.b) - (1.0/3.0) );
+    float4 Q = float4( max(RGB.r, P.x), P.y, (RGB.r < P.x) ? P.w : P.z, min(RGB.r, P.x) );
+    float C = max(Q.x - Q.w, Q.x - Q.y);
     float H = abs((Q.w - Q.y) / (6 * C + Epsilon) + Q.z);
     return float3(H, C, Q.x);
 }
@@ -54,31 +58,42 @@ float3 HSVLerp(float3 col1, float3 col2, float t)
     return HSVtoRGB(lerp(col1, col2, t));
 }
 
-// https://gist.github.com/mairod/a75e7b44f68110e1576d77419d608786
-float3 hueShift( float3 color, float hueAdjust ){
-    hueAdjust *= UNITY_PI * 2;
+// Hue shift by transforming rgb to a chroma rotatable domain (YIQ), rotate chroma, then convert back to rgb
+// percent: 0 would be 0% hue shift, 1 would be 360 degree rotation
+float3 hueShift( float3 color, float percent) {
+    // https://en.wikipedia.org/wiki/YIQ#From_RGB_to_YIQ
+    const float3x3 rgb_to_yiq = float3x3(
+        0.2990,  0.5870,  0.1140,
+        0.5959, -0.2746, -0.3213,
+        0.2115, -0.5227,  0.3112
+    );
+    // https://en.wikipedia.org/wiki/YIQ#From_YIQ_to_RGB
+    const float3x3 yiq_to_rgb = float3x3(
+        1.0,  0.956,  0.619,
+        1.0, -0.272, -0.647,
+        1.0, -1.106,  1.703
+    );
 
-    const float3  kRGBToYPrime = float3 (0.299, 0.587, 0.114);
-    const float3  kRGBToI      = float3 (0.596, -0.275, -0.321);
-    const float3  kRGBToQ      = float3 (0.212, -0.523, 0.311);
+    // Scale the angle from 0-1 to 0-2pi
+    // which is the cycle length of sin and cos
+    const float tau = 6.28318530718;
+    float theta = percent * tau;
 
-    const float3  kYIQToR     = float3 (1.0, 0.956, 0.621);
-    const float3  kYIQToG     = float3 (1.0, -0.272, -0.647);
-    const float3  kYIQToB     = float3 (1.0, -1.107, 1.704);
+    // Convert the colour to the yiq colour system
+    float3 yiq = mul(rgb_to_yiq, color);
 
-    float   YPrime  = dot (color, kRGBToYPrime);
-    float   I       = dot (color, kRGBToI);
-    float   Q       = dot (color, kRGBToQ);
-    float   hue     = atan2 (Q, I);
-    float   chroma  = sqrt (I * I + Q * Q);
+    // Rotate around the x axis (IQ plane)
+    // This rotates the chrominance plane / hue shifts
+    float s = sin(theta), c = cos(theta);
+    float3x3 rotor = float3x3(
+        1, 0,  0,
+        0, c, -s,
+        0, s,  c
+    );
+    float3 yiq_new = mul(rotor, yiq);
 
-    hue += hueAdjust;
-
-    Q = chroma * sin (hue);
-    I = chroma * cos (hue);
-
-    float3    yIQ   = float3 (YPrime, I, Q);
-
-    return float3( dot (yIQ, kYIQToR), dot (yIQ, kYIQToG), dot (yIQ, kYIQToB) );
-
+    // Convert back to RGB
+    return mul(yiq_to_rgb, yiq_new);
 }
+
+#endif //VIVIFY_COLOR_FUNCTIONS_INCLUDED

--- a/Assets/VivifyTemplate/Utilities/Shader Functions/Easings.cginc
+++ b/Assets/VivifyTemplate/Utilities/Shader Functions/Easings.cginc
@@ -1,15 +1,22 @@
-// https://easings.net/
+#ifndef VIVIFY_EASING_FUNCTIONS_INCLUDED
+#define VIVIFY_EASING_FUNCTIONS_INCLUDED
+// Easing functions from https://easings.net/ aggressively optimized for shaders.
+// All functions are branchless, continuous (no jumping), f(0) = 0, f(1) = 1, and unless specified, 0 <= y <= 1.
+// A direct comparison is given in the form of a desmos graph lol https://www.desmos.com/calculator/ywcku5k4mp
 
 float easeInSine(float x) {
-    return 1 - cos((x * UNITY_PI) / 2);
+    const float hpi = 1.57079632679;
+    return 1 - cos(hpi * x);
 }
 
 float easeOutSine(float x) {
-    return sin((x * UNITY_PI) / 2);
+    const float hpi = 1.57079632679;
+    return sin(hpi * x);
 }
 
 float easeInOutSine(float x) {
-    return - (cos(UNITY_PI * x) - 1) / 2;
+    const float hpi = 1.57079632679;
+    return pow(sin(hpi * x), 2);
 }
 
 float easeInQuad(float x) {
@@ -17,11 +24,12 @@ float easeInQuad(float x) {
 }
 
 float easeOutQuad(float x) {
-    return 1 - (1 - x) * (1 - x);
+    return (2 - x) * x;
 }
 
 float easeInOutQuad(float x) {
-    return x < 0.5 ? 2 * x * x : 1 - pow(-2 * x + 2, 2) / 2;
+    x -= 0.5;
+    return (x - x * abs(x)) * 2 + 0.5;
 }
 
 float easeInCubic(float x) {
@@ -29,11 +37,15 @@ float easeInCubic(float x) {
 }
 
 float easeOutCubic(float x) {
-    return 1 - pow(1 - x, 3);
+    return x * ((x - 3) * x + 3);
 }
 
 float easeInOutCubic(float x) {
-    return x < 0.5 ? 4 * x * x * x : 1 - pow(-2 * x + 2, 3) / 2;
+    float f;
+    x -= 0.5;
+    f = 4 * abs(x) - 6;
+    f = f * abs(x) + 3;
+    return f * x + 0.5;
 }
 
 float easeInQuart(float x) {
@@ -45,7 +57,12 @@ float easeOutQuart(float x) {
 }
 
 float easeInOutQuart(float x) {
-    return x < 0.5 ? 8 * x * x * x * x : 1 - pow(-2 * x + 2, 4) / 2;
+    float f;
+    x -= 0.5;
+    f = -8 * abs(x) + 16;
+    f =  f * abs(x) - 12;
+    f =  f * abs(x) + 4;
+    return f * x + 0.5;
 }
 
 float easeInQuint(float x) {
@@ -57,25 +74,30 @@ float easeOutQuint(float x) {
 }
 
 float easeInOutQuint(float x) {
-    return x < 0.5 ? 16 * x * x * x * x * x : 1 - pow(-2 * x + 2, 5) / 2;
+    float f;
+    x -= 0.5;
+    f = 16 * abs(x) - 40;
+    f =  f * abs(x) + 40;
+    f =  f * abs(x) - 20;
+    f =  f * abs(x) + 5;
+    return f * x + 0.5;
 }
 
 float easeInExpo(float x) {
-    return pow(2, 10 * x - 10);
+    const float S = 1.0 / 1023.0;
+    return exp2(10 * x) * S - S;
 }
 
 float easeOutExpo(float x) {
-    return pow(2, -10 * x);
+    const float S = 1024.0 / 1023.0;
+    return -S * exp2(-10 * x) + S;
 }
 
 float easeInOutExpo(float x) {
-    return x == 0
-        ? 0
-        : x == 1
-        ? 1
-        : x < 0.5
-        ? pow(2, 20 * x - 10) / 2
-        : (2 - pow(2, -20 * x + 10)) / 2;
+    x = x * 20 - 10;
+    const float S = 512.0 / 1023.0;
+    float m = 1 - 2 * float(x < abs(x)); //sign(x)
+    return (S - S * exp2(-abs(x))) * m + 0.5;
 }
 
 float easeInCirc(float x) {
@@ -83,91 +105,109 @@ float easeInCirc(float x) {
 }
 
 float easeOutCirc(float x) {
-    return sqrt(1 - pow(x - 1, 2));
+    return sqrt((2 - x) * x);
 }
 
 float easeInOutCirc(float x) {
-    return x < 0.5
-        ? (1 - sqrt(1 - pow(2 * x, 2))) / 2
-        : (sqrt(1 - pow(-2 * x + 2, 2)) + 1) / 2;
+    x -= 0.5;
+    float m = 1 - 2 * float(x < abs(x)); //sign(x)
+    return sqrt(abs(x) - abs(x) * abs(x)) * m + 0.5;
 }
 
+// RANGE: -0.100004 <= y <= 1 (0.419897, -0.100004)
 float easeInBack(float x) {
-    float c1 = 1.70158;
-    float c3 = c1 + 1;
-
-    return c3 * x * x * x - c1 * x * x;
+    return x * x * (2.70158 * x - 1.70158);
 }
 
+// RANGE: 0 <= y <= 1.100004 (0.580103, 1.100004)
 float easeOutBack(float x) {
-    float c1 = 1.70158;
-    float c3 = c1 + 1;
-
-    return 1 + c3 * pow(x - 1, 3) + c1 * pow(x - 1, 2);
+    return x * ((2.70158 * x - 6.40316) * x + 4.70158);
 }
 
+// RANGE: -0.100151 <= y <= 1.100151
+// lo: (0.24061, -0.100151)
+// hi: (0.75939, 1.100151)
 float easeInOutBack(float x) {
-    float c1 = 1.70158;
-    float c2 = c1 * 1.525;
-
-    return x < 0.5
-        ? (pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
-        : (pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
+    float f;
+    x -= 0.5;
+    f = 14.379638 * abs(x) - 16.379638;
+    f = f * abs(x) + 5.5949095;
+    return f * x + 0.5;
 }
 
+// RANGE: -0.372428 <= y <= 1 (0.86526, -0.372428)
 float easeInElastic(float x) {
-    float c4 = (2 * UNITY_PI) / 3;
+    const float pi = 3.14159265359;
+    const float sin_m = 20.0 * pi / 3.0;
+    const float sin_b = -43.0 * pi / 6.0;
+    const float m = -2048.0 / 2049.0;
+    const float b = 1.0 / 2049.0;
 
-    return x == 0
-        ? 0
-        : x == 1
-        ? 1
-        : -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
+    float f = exp2(x * 10 - 10) * sin(sin_m * x + sin_b);
+    return f * m + b;
 }
 
+// RANGE: 0 <= y <= 1.372428 (0.13474, 1.372428)
 float easeOutElastic(float x) {
-    float c4 = (2 * UNITY_PI) / 3;
+    const float pi = 3.14159265359;
+    const float sin_m = 20.0 * pi / 3.0;
+    const float sin_b = -pi * 0.5;
+    const float m = 2.0 / 2049.0;
+    const float b = 2048.0 / 2049.0;
 
-    return x == 0
-        ? 0
-        : x == 1
-        ? 1
-        : pow(2, -10 * x) * sin((x * 10 - 0.75) * c4) + 1;
+    float f = exp2(-10 * x + 10) * sin(sin_m * x + sin_b);
+    return f * m + b;
 }
 
+// RANGE: -0.118453 <= y <= 1.118453
+// lo: (0.404001, -0.118453)
+// hi: (0.595999, 1.118453)
 float easeInOutElastic(float x) {
-    float c5 = (2 * UNITY_PI) / 4.5;
+    const float pi = 3.14159265359;
+    const float sin_m = 80.0 * pi / 9.0;
+    const float sin_b = -89.0 * pi / 18.0;
+    const float m = 512.0 / (1024.0 - sin(pi / 18.0));
+    const float b = 0.5;
 
-    return x == 0
-        ? 0
-        : x == 1
-        ? 1
-        : x < 0.5
-        ? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
-        : (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
-}
-
-float easeOutBounce(float x) {
-    float n1 = 7.5625;
-    float d1 = 2.75;
-
-    if (x < 1 / d1) {
-        return n1 * x * x;
-    } else if (x < 2 / d1) {
-        return n1 * (x -= 1.5 / d1) * x + 0.75;
-    } else if (x < 2.5 / d1) {
-        return n1 * (x -= 2.25 / d1) * x + 0.9375;
-    } else {
-        return n1 * (x -= 2.625 / d1) * x + 0.984375;
-    }
+    float v = 20 * x - 10;
+    float s = 1 - 2 * float(v < abs(v)); //sign(v)
+    float f = exp2(-abs(v)) * sin(sin_m * x + sin_b);
+    return (f * s + s) * m + b;
 }
 
 float easeInBounce(float x) {
-    return 1 - easeOutBounce(1 - x);
+    const float M = -121.0 / 16.0;
+    const float4 OFFSET = float4(11, 44, 110, 242) / 16.0;
+    const float4 BIAS = float4(0, 3, 21, 105) / 16.0;
+
+    float4 p = (M * x + OFFSET) * x - BIAS;
+    return max(max(p.x, p.y), max(p.z, p.w));
+}
+
+float easeOutBounce(float x) {
+    const float M = 121.0 / 16.0;
+    const float4 OFFSET = float4(0, 132, 198, 231) / 16.0;
+    const float4 BIAS = float4(0, 3, 6, 63.0 / 8.0);
+
+    float4 p = (M * x - OFFSET) * x + BIAS;
+    return min(min(p.x, p.y), min(p.z, p.w));
 }
 
 float easeInOutBounce(float x) {
-    return x < 0.5
-        ? (1 - easeOutBounce(1 - 2 * x)) / 2
-        : (1 + easeOutBounce(2 * x - 1)) / 2;
+    float v = x * 2 - 1;
+    float f = sign(v) * easeOutBounce(abs(v));
+    return f * 0.5 + 0.5;
 }
+
+// EaseInOut but generalized to the `n`th power.
+// easeInOutNth(x, 2) -> Quad
+// easeInOutNth(x, 3) -> Cubic
+// easeInOutNth(x, 4) -> Quart
+// etc.
+float easeInOutNth(float x, float n) {
+    //x = saturate(x);
+    float2 v = min(float2(2 - 2 * x, 2 * x), 1);
+    return (pow(v.y, n) - pow(v.x, n)) * 0.5 + 0.5;
+}
+
+#endif //VIVIFY_EASING_FUNCTIONS_INCLUDED

--- a/Assets/VivifyTemplate/Utilities/Shader Functions/Math.cginc
+++ b/Assets/VivifyTemplate/Utilities/Shader Functions/Math.cginc
@@ -1,23 +1,31 @@
+#ifndef VIVIFY_MATH_FUNCTIONS_INCLUDED
+#define VIVIFY_MATH_FUNCTIONS_INCLUDED
+
+// Transforms a position in object/local space to worldspace
 float3 localToWorld(float3 pos)
 {
     return mul(unity_ObjectToWorld, float4(pos, 1));
 }
 
+// Transforms a position in worldspace to object/local space
 float3 worldToLocal(float3 pos)
 {
     return mul(unity_WorldToObject, float4(pos, 1));
 }
 
+// Constructs a vector from the worldspace camera position (as the tail) towards the `worldPos` position (as the tip)
 float3 viewVectorFromWorld(float3 worldPos)
 {
     return worldPos - _WorldSpaceCameraPos;
 }
 
+// Transforms an object/local space position into world space, and returns the vector from the camera to that position
 float3 viewVectorFromLocal(float3 localPos)
 {
     return viewVectorFromWorld(localToWorld(localPos));
 }
 
+// Projects the viewVector onto a plane 1 unit forward
 float3 unwarpViewVector(float3 viewVector)
 {
     return viewVector / dot(viewVector, unity_WorldToCamera._m20_m21_m22);
@@ -30,21 +38,26 @@ float3 viewVectorFromUV(float2 uv)
     return mul(unity_CameraToWorld, float4(viewDir, 0)).xyz;
 }
 
+// Returns the cameras worldspace forward direction
 float3 getCameraForward()
 {
     return mul((float3x3)unity_CameraToWorld, float3(0,0,1));
 }
 
+// Returns the direction towards the current light in context (typically the directional sun light)
 float3 getLightDirection()
 {
     return normalize(_WorldSpaceLightPos0.xyz);
 }
 
-float4 sampleReflectionProbe(float3 viewVector) 
+// Samples the currently active reflection probe, in the direction of `viewVector`
+float4 sampleReflectionProbe(float3 viewVector)
 {
     return float4(DecodeHDR(UNITY_SAMPLE_TEXCUBE_LOD(unity_SpecCube0, viewVector, 0), unity_SpecCube0_HDR), 0);
 }
 
+// Rotates point `p` counter-clockwise by `a` radians
+// Positive rotations will rotate the X axis towards the Y axis
 float2 rotate2D(float a, float2 p)
 {
     float c = cos(a);
@@ -52,7 +65,8 @@ float2 rotate2D(float a, float2 p)
     return mul(float2x2(c, -s, s, c), p);
 }
 
-float3 rotateX(float a, float3 p) 
+// Rotates point `p` around the X axis by `a` radians
+float3 rotateX(float a, float3 p)
 {
     return float3(
         p.x,
@@ -60,7 +74,8 @@ float3 rotateX(float a, float3 p)
     );
 }
 
-float3 rotateY(float a, float3 p) 
+// Rotates point `p` around the Y axis by `a` radians
+float3 rotateY(float a, float3 p)
 {
     float2 xz = rotate2D(a, p.xz);
 
@@ -71,7 +86,8 @@ float3 rotateY(float a, float3 p)
     );
 }
 
-float3 rotateZ(float a, float3 p) 
+// Rotates point `p` around the Z axis by `a` radians
+float3 rotateZ(float a, float3 p)
 {
     return float3(
         rotate2D(a, p.xy),
@@ -79,48 +95,65 @@ float3 rotateZ(float a, float3 p)
     );
 }
 
-float3 rotatePoint(float3 a, float3 p) 
+// Rotates a point `p` by radian angles from `a`
+float3 rotatePoint(float3 a, float3 p)
 {
-    float cx = cos(a.x);
-    float sx = sin(a.x);
-    float cy = cos(a.y);
-    float sy = sin(a.y);
-    float cz = cos(a.z);
-    float sz = sin(a.z);
-    
-    return float3(
-        p.x * (cy*cx) + p.y * (sz*sy*cx - cz*sx) + p.z * (cz*sy*cx + sz*sx),
-        p.x * (cy*sx) + p.y * (sz*sy*sx + cz*cx) + p.z * (cz*sy*sx - sz*cx),
-        p.x * (-sy) + p.y * (sz*cy) + p.z * (cz*cy)
+    float3 c = cos(a);
+    float3 s = sin(a);
+    float3x3 rotor = float3x3(
+        c.y*c.x, s.z*s.y*c.x - c.z*s.x, c.z*s.y*c.x + s.z*s.x,
+        c.y*s.x, s.z*s.y*s.x + c.z*c.x, c.z*s.y*s.x - s.z*c.x,
+        -s.y, s.z*c.y, c.z*c.y
     );
+    return mul(rotor, p);
 }
 
+// Projects the ray from `linePoint` towards `lineDir` onto the plane at with y=`planeY`
+// linePoint: The starting point of the line, (for instance, your cameras world position)
+// lineDir: The direction of the line, or the endpoint of the line (for instance, your i.vertex in worldspace)
+// planeY: The y level of the XZ plane
+// Note: `lineDir` does not need to be normalized, as the scale of the direction vector is accounted for in the division.
 float3 lineXZPlaneIntersect(float3 linePoint, float3 lineDir, float planeY)
 {
-    lineDir = normalize(lineDir);
     float t = (planeY - linePoint.y) / lineDir.y;
     return linePoint + t * lineDir;
 }
 
+float3 linePlaneIntersect(float3 rayPos, float3 rayDir, float3 planePos, float3 planeNormal)
+{
+    float3 localCam = planePos - rayPos;
+    float t = dot(localCam, planeNormal) / dot(rayDir, planeNormal);
+    return rayPos + t * rayDir;
+}
+
+// Returns the cosine of the angle between two vectors.
+// -1 if the vectors are facing the complete opposite way from each other
+// 0 if the vectors are 90 degrees from each other (orthogonal)
+// +1 if the vectors are facing the exact same direction
+// Note: if you want the angle in radians, use acos(angleBetweenVectors(a, b))
+// keep in mind acos is expensive though, but if you're doing cos(acos(angle)), they will cancel.
 float angleBetweenVectors(float2 a, float2 b)
 {
-    return dot(a, b) / (length(a) * length(b));
+    return dot(a, b) * rsqrt(dot(a,a) * dot(b,b));
 }
 
 float angleBetweenVectors(float3 a, float3 b)
 {
-    return dot(a, b) / (length(a) * length(b));
+    return dot(a, b) * rsqrt(dot(a,a) * dot(b,b));
 }
 
+// https://www.youtube.com/watch?v=PMltMdi1Wzg
+// Projects a point `p` onto a line from `linePoint1` to `linePoint2`
+// feel free to saturate `t` if you dont want it to go past the endpoints of the line.
 float3 closestPointOnLine(float3 linePoint1, float3 linePoint2, float3 p)
 {
-    float3 lineDirection = normalize(linePoint2 - linePoint1);
-    float3 toPoint = p - linePoint1;
-
-    float projection = dot(toPoint, lineDirection);
-    return linePoint1 + projection * lineDirection;
+    float3 ba = linePoint2 - linePoint1;
+    float3 pa = p - linePoint1;
+    float t = dot(ba, pa) / dot(ba, ba);
+    return lerp(linePoint1, linePoint2, t);
 }
 
+// Constructs a 3x3 matrix from column vectors `x`, `y`, `z`
 float3x3 matrixFromBasis(float3 x, float3 y, float3 z)
 {
     return float3x3(
@@ -130,11 +163,19 @@ float3x3 matrixFromBasis(float3 x, float3 y, float3 z)
     );
 }
 
-float3 directionToCamera()
+// Returns the transform.position or "pivot" position of the mesh in worldspace
+float3 getObjectTransformPos()
 {
-    return _WorldSpaceCameraPos - localToWorld(0);
+    return unity_ObjectToWorld._m03_m13_m23;
 }
 
+// Constructs a vector from the objects transform pivot position to the cameras worldspace position
+float3 directionToCamera()
+{
+    return _WorldSpaceCameraPos - getObjectTransformPos();
+}
+
+// Creates a lookAt matrix based on a `forward` direction, and applies the rotation to a point `p`
 float3 rotateLook(float3 forward, float3 p)
 {
     forward = normalize(forward);
@@ -149,6 +190,7 @@ float3 rotateLook(float3 forward, float3 p)
     return -mul(m, p);
 }
 
+// Applies rotateLook but local to an `up` vector, defining the normal of the rotation plane.
 float3 rotateLookOnAxis(float3 forward, float3 up, float3 p)
 {
     forward = normalize(forward);
@@ -161,3 +203,5 @@ float3 rotateLookOnAxis(float3 forward, float3 up, float3 p)
 
     return -mul(m, p);
 }
+
+#endif //VIVIFY_MATH_FUNCTIONS_INCLUDED


### PR DESCRIPTION
I rewrote the functions in `Easings.cginc` for graphics hardware and improving them. All easing functions are now
- continuous everywhere (no animation jumps)
- guaranteed to return 0 when x=0, and 1 when x=1
- branchless and tuned towards parallelization
- Ranging between 0 to 1 unless specified

I updated the hueShift function in `Colors.cginc` to implement RGB -> YIQ -> rotate chroma plane -> RGB instead.
I commented the majority of the functions in `Math.cginc` for clarity of others who may use them.
`Noise.cginc` is a whole other problem in itself.
And lastly, #ifdef guards to avoid getting a suite of errors if a cginc file is included more than once in a single shader (or other cginc files)

Everything *should* be 1:1 in functionality. If that isn't the case im happy to fix whatever!