### PR TITLE
Replaced exporter windows bundle TextField with an enum dropdown

### DIFF
--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/PlayerPrefs/ProjectBundle.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/PlayerPrefs/ProjectBundle.cs
@@ -5,11 +5,12 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.PlayerPrefs
 {
     public static class ProjectBundle
     {
+        public static readonly string DefaultValue = "bundle";
         private readonly static string PlayerPrefsKey = "projectBundle";
 
         public static string Value
         {
-            get => UnityEngine.PlayerPrefs.GetString(PlayerPrefsKey, "bundle");
+            get => UnityEngine.PlayerPrefs.GetString(PlayerPrefsKey, DefaultValue);
             set => UnityEngine.PlayerPrefs.SetString(PlayerPrefsKey, value);
         }
     }

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace VivifyTemplate.Exporter.Scripts.Editor.Utility
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Removes `target` from the end of `src` if found
+        /// </summary>
+        /// <param name="src">Input string to trim</param>
+        /// <param name="target">Substring to remove from input</param>
+        /// <param name="comparison">Handles cultural case-sensitive stuff</param>
+        /// <returns>The trimmed string</returns>
+        public static string TrimEnd(this string src, string target, StringComparison comparison = StringComparison.CurrentCulture)
+        {
+            if(target != null && src.EndsWith(target, comparison))
+            {
+                return src.Substring(0, src.Length - target.Length);
+            }
+
+            return src;
+        }
+    }
+}

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs.meta
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8de2a07afac969d439847163c3ef7d95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Pretty simple change, but a good quality of life.

I've replaced the exporter windows "Bundle To Export" field with a dropdown containing all the asset bundles in your unity project. 
If there are no bundles in the scene, or the bundle stored in `ProjectBundle.Value` doesnt exist anymore, A stand-in option will come in the form of `{name}_??` to denote its unknown. If you select a different asset bundle from the list, this temporary will be removed. If you add a new asset bundle or add an asset bundle back in, the list updates `OnFocus`.

To my knowledge this shouldnt have any adverse effects? 
I've handled the potential to have `ProjectBundle` set to the unknown bundle name with `_??`, which implies building with an unknown bundle name will result in the same functionality as setting the text field to your bundles original name, but those two should be the only possible problems here..
<img width="552" height="122" alt="Bundle in dropdown" src="https://github.com/user-attachments/assets/ce1875d5-1108-440a-985f-64e6a1274913" />
<img width="552" height="70" alt="Unknown bundle name" src="https://github.com/user-attachments/assets/a49d5032-1c77-45b2-a92e-cb6e60b2394b" />

