### PR TITLE
Update unity versions to refer to security patched versions

### DIFF
--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/QuestSupport/QuestSetup.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/QuestSupport/QuestSetup.cs
@@ -43,7 +43,7 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.QuestSupport
 
             if (State == BackgroundTaskState.Idle && (QuestPreferences.UnityEditor == "" || !Directory.Exists(Path.GetDirectoryName(QuestPreferences.UnityEditor))))
             {
-                if (HubWrapper.TryGetUnityEditor("2021.3.16f1", out var foundVersion) && Directory.Exists(Path.GetDirectoryName(foundVersion)))
+                if (HubWrapper.TryGetUnityEditor("2021.3.45f2", out var foundVersion) && Directory.Exists(Path.GetDirectoryName(foundVersion)))
                 {
                     QuestPreferences.UnityEditor = foundVersion;
                 }
@@ -56,7 +56,7 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.QuestSupport
                     };
 
                     EditorGUILayout.Space(10);
-                    EditorGUILayout.LabelField("Could not find Unity Editor version 2021.3.16f1. This version is required to build quest bundles.", style, GUILayout.Height(style.fontSize * 2));
+                    EditorGUILayout.LabelField("Could not find Unity Editor version 2021.3.45f2. This version is required to build quest bundles.", style, GUILayout.Height(style.fontSize * 2));
                     EditorGUILayout.Space(10);
 
                     GUI.enabled = State != BackgroundTaskState.DownloadingEditor;
@@ -65,7 +65,7 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.QuestSupport
                     GUILayout.Space(80);
                     if (GUILayout.Button("Download", GUILayout.Height(30)))
                     {
-                        Application.OpenURL("unityhub://2021.3.16f1/4016570cf34f");
+                        Application.OpenURL("unityhub://2021.3.45f2/88f88f591b2e");
                     }
                     if (GUILayout.Button("Rescan", GUILayout.Height(30)))
                     {
@@ -101,11 +101,11 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.QuestSupport
                 if (!Directory.Exists(androidPlaybackEngine))
                 {
                     EditorGUILayout.LabelField(
-                        "Could not find the Android Build Module for Unity Editor version 2021.3.16f1. This module is required to build quest bundles.");
+                        "Could not find the Android Build Module for Unity Editor version 2021.3.45f2. This module is required to build quest bundles.");
                     GUI.enabled = State != BackgroundTaskState.DownloadingAndroidBuildSupport;
                     if (GUILayout.Button("Download Android Build Module. Under \"Component Installers\""))
                     {
-                        Application.OpenURL("https://unity.com/releases/editor/whats-new/2021.3.16#installers");
+                        Application.OpenURL("https://unity.com/releases/editor/whats-new/2021.3.45f2#installs");
                     }
 
                     GUI.enabled = true;
@@ -159,7 +159,7 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.QuestSupport
 
             EditorGUILayout.LabelField("What Is This?", headerStyle, GUILayout.Height(headerStyle.fontSize * 2));
             EditorGUILayout.LabelField(
-                "To build vivify bundles for quest predictably, accurately, and easily, you need to build with Unity 2021.3.16f1",
+                "To build vivify bundles for quest predictably, accurately, and easily, you need to build with Unity 2021.3.45f2",
                 paragraphStyle);
             EditorGUILayout.LabelField(
                 "<b><i>Luckily, this template will handle all of that for you!</i></b> It will setup the project for you, link your assets, and build your bundle all on its own!",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VivifyTemplate is a tool designed for the Unity side development of [Vivify](htt
 
 # Setup
 
-1. Create and open a Unity project for version **2019.4.28f1**. The download will be somewhere on [this page](https://unity.com/releases/editor/archive).
+1. Create and open a Unity project for version **2019.4.41f1**. The download will be somewhere on [this page](https://unity.com/releases/editor/archive).
 2. Download whatever VivifyTemplate modules you want from the [latest release](https://github.com/Swifter1243/VivifyTemplate/releases).
 3. Install them by double-clicking them. Follow the import instructions in your editor.
 
@@ -23,7 +23,7 @@ If you are trying to update any modules in your project, please delete the old o
 The exporter handles exporting bundles for various versions of Unity and Beat Saber.
 - **Windows 2019**: PC Beat Saber 1.29.1, uses `Single Pass`.
 - **Windows 2021**: PC Beat Saber 1.34.2+, uses `Single Pass Instanced`.
-- **Android 2021**: Quest Beat Saber. Uses `Single Pass Instanced`
+- **Android 2021**: Quest Beat Saber. Uses `Multiview`
 
 It also exports a `bundleinfo.json` file which contains the correct bundle checksums, among other information.
 
@@ -108,7 +108,7 @@ If you installed the "Utilities" package, a few tools will be provided from the 
 
 ## TextMeshPro
 
-The version of TextMeshPro that is installed with Unity version **2019.4.28f1** is newer than what Beat Saber uses in 1.29.1, and therefore causes some alignment issues. In order to downgrade:
+The version of TextMeshPro that is installed with Unity version **2019.4.41f1** is newer than what Beat Saber uses in 1.29.1, and therefore causes some alignment issues. In order to downgrade:
 - Go to `Window > Package Manager`
 - Find TextMeshPro and remove it.
 - Click the `+` and click "Add package from git URL".


### PR DESCRIPTION
Bump quest and pc unity versions to nearest minor version update that is patched for the security advisory

https://unity.com/security/sept-2025-01