### PR TITLE
"Bundle To Export" uses dropdown instead

### DIFF
--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/PlayerPrefs/ProjectBundle.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/PlayerPrefs/ProjectBundle.cs
@@ -5,11 +5,12 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.PlayerPrefs
 {
     public static class ProjectBundle
     {
+        public static readonly string DefaultValue = "bundle";
         private readonly static string PlayerPrefsKey = "projectBundle";
 
         public static string Value
         {
-            get => UnityEngine.PlayerPrefs.GetString(PlayerPrefsKey, "bundle");
+            get => UnityEngine.PlayerPrefs.GetString(PlayerPrefsKey, DefaultValue);
             set => UnityEngine.PlayerPrefs.SetString(PlayerPrefsKey, value);
         }
     }

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/UI/BuildConfigurationWindow.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/UI/BuildConfigurationWindow.cs
@@ -21,6 +21,7 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
         private Texture2D _tbsLogo;
 
         // Asset bundle properties
+        private static bool _showLegacyBundleString = false;
         private static readonly string _defaultBundleID = " (default)";
         private static readonly string _missingBundleID = " (missing)";
         private static int _assetBundleIndex;
@@ -42,6 +43,11 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
 
         private void UpdateAssetBundleList()
         {
+            if(_showLegacyBundleString)
+            {
+                return;
+            }
+
             // Gather the asset bundles in this project
             string[] bundleNames = AssetDatabase.GetAllAssetBundleNames();
 
@@ -237,16 +243,37 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
             EditorGUILayout.LabelField("Settings", _titleStyle, GUILayout.Height(_titleStyle.fontSize * 1.5f));
 
             _compressed = EditorGUILayout.Toggle(new GUIContent("Compressed", "Whether to compress the bundle. This will take longer, but will significantly reduce file size."), _compressed);
-            
+
             /* == Bundle dropdown == */
+
+            _showLegacyBundleString = EditorGUILayout.Toggle(new GUIContent("Use Bundle Name String", "Use the older string method for \"Bundle To Export\"."), _showLegacyBundleString);
+            GUIContent bundleToExportGUI = new GUIContent("Bundle To Export", "Assets attached to this bundle name will be exported.");
+            if(_showLegacyBundleString)
+            {
+                ProjectBundle.Value = EditorGUILayout.TextField(bundleToExportGUI, ProjectBundle.Value);
+            }
+            else
+            {
+                DrawAssetBundleDropdown(bundleToExportGUI);
+            }
+
+            ShouldExportBundleInfo.Value = EditorGUILayout.Toggle(new GUIContent("Export Bundle Info", "Whether to export the bundleinfo.json file."), ShouldExportBundleInfo.Value);
+
+            if (ShouldExportBundleInfo.Value) {
+                ShouldPrettifyBundleInfo.Value = EditorGUILayout.Toggle(new GUIContent("Prettify Bundle Info", "Whether to format the bundleinfo.json with indents and new lines."), ShouldPrettifyBundleInfo.Value);
+            }
+
+            GUIOutputDirectory();
+        }
+
+        private void DrawAssetBundleDropdown(GUIContent bundleToExportGUI)
+        {
             if(_assetBundleNames == null)
             {
                 UpdateAssetBundleList();
             }
 
-            GUIContent bundleToExportGUI = new GUIContent("Bundle To Export", "Assets attached to this bundle name will be exported.");
-
-            if (_assetBundleNames == null)
+            if(_assetBundleNames == null)
             {
                 // Fallback to the normal string method if for some reason the asset bundle stuff doesnt work
                 ProjectBundle.Value = EditorGUILayout.TextField(bundleToExportGUI, ProjectBundle.Value);
@@ -271,15 +298,6 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
                     UpdateAssetBundleList();
                 }
             }
-            /* == Bundle dropdown == */
-
-            ShouldExportBundleInfo.Value = EditorGUILayout.Toggle(new GUIContent("Export Bundle Info", "Whether to export the bundleinfo.json file."), ShouldExportBundleInfo.Value);
-
-            if (ShouldExportBundleInfo.Value) {
-                ShouldPrettifyBundleInfo.Value = EditorGUILayout.Toggle(new GUIContent("Prettify Bundle Info", "Whether to format the bundleinfo.json with indents and new lines."), ShouldPrettifyBundleInfo.Value);
-            }
-
-            GUIOutputDirectory();
         }
 
         private static void GUIOutputDirectory()

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/UI/BuildConfigurationWindow.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/UI/BuildConfigurationWindow.cs
@@ -20,10 +20,66 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
 
         private Texture2D _tbsLogo;
 
+        // Asset bundle properties
+        private static readonly string _defaultBundleID = " (default)";
+        private static readonly string _missingBundleID = " (missing)";
+        private static int _assetBundleIndex;
+        private static string[] _assetBundleNames;
+
         private void OnEnable()
         {
             // there has to be better way to do this lol
             _tbsLogo = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/VivifyTemplate/Exporter/Textures/TBS_trans.png");
+
+            UpdateAssetBundleList();
+        }
+
+        private void OnFocus()
+        {
+            // Update the asset bundle list when the window has focus
+            UpdateAssetBundleList();
+        }
+
+        private void UpdateAssetBundleList()
+        {
+            // Gather the asset bundles in this project
+            string[] bundleNames = AssetDatabase.GetAllAssetBundleNames();
+
+            // Search for the PlayerPrefs bundle name and default name in the project bundles
+            bool targetInProject = Array.Exists(bundleNames, x => x.Equals(ProjectBundle.Value));
+            bool defaultInProject = Array.Exists(bundleNames, x => x.Equals(ProjectBundle.DefaultValue));
+
+            // Get the projects selected bundle
+            string selectedBundleName = ProjectBundle.Value;
+
+            // Create a list with default, selected, and the rest of the project bundles
+            List<string> bundles = new List<string>(capacity: bundleNames.Length + 2)
+            {
+                ProjectBundle.DefaultValue,
+                selectedBundleName
+            };
+            bundles.AddRange(bundleNames);
+
+            // Remove duplicate entries and convert to an array
+            _assetBundleNames = bundles.Distinct().ToArray();
+
+            // Find PlayerPrefs index
+            _assetBundleIndex = Array.FindIndex(_assetBundleNames, x => x.Equals(selectedBundleName));
+
+            // True when the first asset bundle is the project target
+            bool firstIsTarget = targetInProject && _assetBundleIndex == 0;
+
+            // add the default identifier text unless the index is the first and its found in this project
+            if(!defaultInProject && !firstIsTarget)
+            {
+                _assetBundleNames[0] += _defaultBundleID;
+            }
+
+            // Add the missing identifier if the target is not found in the project
+            if(!targetInProject && _assetBundleIndex != 0)
+            {
+                _assetBundleNames[_assetBundleIndex] += _missingBundleID;
+            }
         }
 
         private void VersionToggle(string label, BuildVersion version)
@@ -181,7 +237,42 @@ namespace VivifyTemplate.Exporter.Scripts.Editor.UI
             EditorGUILayout.LabelField("Settings", _titleStyle, GUILayout.Height(_titleStyle.fontSize * 1.5f));
 
             _compressed = EditorGUILayout.Toggle(new GUIContent("Compressed", "Whether to compress the bundle. This will take longer, but will significantly reduce file size."), _compressed);
-            ProjectBundle.Value = EditorGUILayout.TextField(new GUIContent("Bundle To Export", "Assets attached to this bundle name will be exported."), ProjectBundle.Value);
+            
+            /* == Bundle dropdown == */
+            if(_assetBundleNames == null)
+            {
+                UpdateAssetBundleList();
+            }
+
+            GUIContent bundleToExportGUI = new GUIContent("Bundle To Export", "Assets attached to this bundle name will be exported.");
+
+            if (_assetBundleNames == null)
+            {
+                // Fallback to the normal string method if for some reason the asset bundle stuff doesnt work
+                ProjectBundle.Value = EditorGUILayout.TextField(bundleToExportGUI, ProjectBundle.Value);
+            }
+            else
+            {
+                EditorGUI.BeginChangeCheck();
+                {
+                    _assetBundleIndex = EditorGUILayout.Popup(bundleToExportGUI, _assetBundleIndex, _assetBundleNames);
+                }
+                if(EditorGUI.EndChangeCheck())
+                {
+                    string selected = _assetBundleNames[_assetBundleIndex];
+
+                    // Remove display identifiers when setting ProjectBundle values
+                    selected = selected.TrimEnd(_missingBundleID);
+                    selected = selected.TrimEnd(_defaultBundleID);
+
+                    ProjectBundle.Value = selected;
+
+                    // Update to remove any unknown bundles
+                    UpdateAssetBundleList();
+                }
+            }
+            /* == Bundle dropdown == */
+
             ShouldExportBundleInfo.Value = EditorGUILayout.Toggle(new GUIContent("Export Bundle Info", "Whether to export the bundleinfo.json file."), ShouldExportBundleInfo.Value);
 
             if (ShouldExportBundleInfo.Value) {

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace VivifyTemplate.Exporter.Scripts.Editor.Utility
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Removes `target` from the end of `src` if found
+        /// </summary>
+        /// <param name="src">Input string to trim</param>
+        /// <param name="target">Substring to remove from input</param>
+        /// <param name="comparison">Handles cultural case-sensitive stuff</param>
+        /// <returns>The trimmed string</returns>
+        public static string TrimEnd(this string src, string target, StringComparison comparison = StringComparison.CurrentCulture)
+        {
+            if (target != null && src.EndsWith(target, comparison))
+            {
+                return src.Substring(0, src.Length - target.Length);
+            }
+
+            return src;
+        }
+    }
+}

--- a/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs.meta
+++ b/Assets/VivifyTemplate/Exporter/Scripts/Editor/Utility/Extensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70e8ce08e5acaa04588db1d7c7245a0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Github did some things I didnt like, so im re-pulling this.

The only change here is "Bundle To Export" now creates a dropdown with your projects asset bundle list instead of depending on a text field.
- If the PlayerPrefs asset bundle goes missing, it will be shown as `whatever (missing)`
- If there are no asset bundles found, it will create "bundle" as the default, helpfully denoted as `bundle (default)`
- If for some reason the array is null after trying to find the bundles in the project, it will default back to the original string method.

I have tested a few cases where id expect this to fail, and I've also added a toggle to revert back to the old string method, if someone wants to do that.

<img width="679" height="155" alt="image" src="https://github.com/user-attachments/assets/95701b39-ff63-4a0c-beb4-f3fcd12b36b1" />
